### PR TITLE
Corrected error message when trying to workon a non-existent virtualenv

### DIFF
--- a/invewrapper/invewrapper.py
+++ b/invewrapper/invewrapper.py
@@ -115,26 +115,26 @@ def deploy_inve(target):
 
 def mkvirtualenv(envname, python=None, packages=[], project=None,
 		requirements=None, rest=[]):
-	
+
 	if python:
 		rest = ["--python=%s" % python] + rest
-	
+
 	with chdir(workon_home):
 		os.environ['VIRTUALENV_DISTRIBUTE'] = 'true'
 		check_call(["virtualenv", envname] + rest)
-	
+
 		if project:
 			setvirtualenvproject(envname, project)
-	
+
 	inve = get_inve(envname)
 	deploy_inve(inve)
-	
+
 	if requirements:
 		invoke(inve, 'pip', 'install', '-r', expandpath(requirements))
-	
+
 	if packages:
 		invoke(inve, 'pip', 'install', *packages)
-	
+
 	return inve
 
 
@@ -227,11 +227,11 @@ def workon_cmd():
 	except IndexError:
 		lsvirtualenv(False)
 		return
-	
+
 	env_path = os.path.join(workon_home, env)
 	if not os.path.exists(env_path):
 		sys.exit("ERROR: Environment '{0}' does not exist. Create it with \
-'mkvirtualenv {0}'.".format(env))
+'pew-new {0}'.".format(env))
 	else:
 		inve = get_inve(env)
 		invoke(inve)
@@ -257,7 +257,7 @@ directory; if this file does not exists, it will be created first.
 	parser.add_argument('-d', dest='remove', action='store_true')
 	parser.add_argument('dirs', nargs='+')
 	args = parser.parse_args()
-	
+
 	extra_paths = os.path.join(sitepackages_dir(), '_virtualenv_path_extensions.pth')
 	new_paths = [os.path.abspath(d) + "\n" for d in args.dirs]
 	if not os.path.exists(extra_paths):
@@ -324,7 +324,7 @@ def cp_cmd():
 	target_name = args.get(2, source_name)
 
 	target = os.path.join(workon_home, target_name)
-	
+
 	if os.path.exists(target):
 		sys.exit('%s virtualenv already exists.' % target_name)
 
@@ -357,7 +357,7 @@ def mkproject_cmd():
 					glob(os.path.join(workon_home, "template_*"))]
 		print("Available project templates:\n%s" % "\n".join(templates))
 		sys.exit()
-	
+
 	parser = mkvirtualenv_argparser()
 	parser.add_argument('envname')
 	parser.add_argument(
@@ -368,7 +368,7 @@ command line.')
 		'-l', '--list', action='store_true', help='List available templates.')
 
 	args, rest = parser.parse_known_args()
-	
+
 	projects_home = os.environ.get('PROJECT_HOME', '.')
 	if not os.path.exists(projects_home):
 		sys.exit('ERROR: Projects directory %s does not exist. \


### PR DESCRIPTION
When attempting to pew-workon <non-existent-virtualenv>, the error message used to suggest using mkvirtualenv. Now it suggests using pew-new.

Also stripped blank lines.
