### PR TITLE
Fix tests failing on Travis

### DIFF
--- a/tests/test_mkvirtualenv_install.sh
+++ b/tests/test_mkvirtualenv_install.sh
@@ -21,23 +21,16 @@ setUp () {
     rm -f "$test_dir/catch_output"
 }
 
-skip_if_travis() {
-    [ $TRAVIS ] && startSkipping
-    # don't know why, but the following 2 tests started failing on travis since December 2013
-}
-
 test_single_package () {
-    skip_if_travis
     installed=$(echo "pip freeze" | pew-new -i IPy "env4" )
-    assertTrue "IPy not found in $installed" "echo $installed | grep IPy=="
+    assertTrue "IPy not found in $installed" "echo \"$installed\" | grep IPy=="
 }
 
 test_multiple_packages () {
-    skip_if_travis
 	echo "" | pew-new -i IPy -i WebTest "env5" >/dev/null 
     installed=$(echo "pip freeze" | pew-workon env5 )
-    assertTrue "IPy not found in $installed" "echo $installed | grep IPy=="
-    assertTrue "WebTest not found in $installed" "echo $installed | grep WebTest=="
+    assertTrue "IPy not found in $installed" "echo \"$installed\" | grep IPy=="
+    assertTrue "WebTest not found in $installed" "echo \"$installed\" | grep WebTest=="
 }
 
 . "$test_dir/shunit2"


### PR DESCRIPTION
This reverts commit adfa53f95a54f1ac6227ef0359aa9ffc79b7a5d1 and makes the tests pass.

The issue is not specific to Travis, the tests were failing on my Linux/OS X boxes as well. And that would be the reason:

```
% installed="something something
> IPy==1.2.3"
% eval "echo $installed | grep IPy=="
something something
% echo $?
1
% eval "echo \"$installed\" | grep IPy=="
IPy==1.2.3
% echo $?
0
%
% bash --version
GNU bash, version 3.2.51(1)-release (x86_64-apple-darwin13)
Copyright (C) 2007 Free Software Foundation, Inc.
% sh --version
GNU bash, version 3.2.51(1)-release (x86_64-apple-darwin13)
Copyright (C) 2007 Free Software Foundation, Inc.
```
