### PR TITLE
Add information about archlinux package in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Installation
 
 See the [troubleshooting](#troubleshooting) section, if needed.
 
+There are packages for some linux distributions:
+
+- Archlinux: [AUR package](https://aur.archlinux.org/packages/python-pew/)
+
 Usage
 -----
 


### PR DESCRIPTION
I made a package for archlinux to install pew easily. I think is a good idea to put it in the README, and when more people create new packages for other distributions we can have this list in a central place.
