### PR TITLE
Use sys.executable to determine the current python

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -17,7 +17,7 @@ except ImportError:
     pass # setup.py needs to import this before the dependencies are installed
 
 from pew._utils import (call, check_call, shell, chdir, expandpath, own,
-                        env_bin_dir, check_path, which)
+                        env_bin_dir, check_path)
 
 
 def update_args_dict():
@@ -77,8 +77,7 @@ def invoke(inve, *args):
         if not windows:
             # On Windows the PATH is usually set with System Utility
             # so we won't worry about trying to check mistakes there
-            py = which('python' + str(sys.version_info[0])) # external python
-            shell_check = [py + ' -c "from pew.pew import '
+            shell_check = [sys.executable + ' -c "from pew.pew import '
                            'prevent_path_errors; prevent_path_errors()"']
             if call(['python', inve, args[0], '-c'] + shell_check) != 0:
                 return


### PR DESCRIPTION
Pew currently breaks if running from a python without a version alias
on the PATH. For instance, if using the system Python 2, it will look
for an executable named 'python2' even though it may not exist.
