### PR TITLE
Make `pew in venv` start a subshell

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -87,6 +87,17 @@ def unsetenv(key):
         del os.environ[key]
 
 def inve(env, command=None, *args, **kwargs):
+    """Run a command in the given virtual environment.
+
+    If no command is given, then default to opening a new sub-shell.
+    Which shell will be opened is platform-dependant.
+
+    When the ``guard`` keyword argument is ``True``, run a check to see
+    if the path is set up correctly.
+
+    Pass additional keyword arguments to ``subprocess.check_call()``.
+    """
+
     if not command:
         command = 'powershell' if windows else os.environ['SHELL']
         or_ctrld = '' if windows else "or 'Ctrl+D' "

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -86,7 +86,13 @@ def unsetenv(key):
     if key in os.environ:
         del os.environ[key]
 
-def inve(env, command, *args, **kwargs):
+def inve(env, command=None, *args, **kwargs):
+    if not command:
+        command = 'powershell' if windows else os.environ['SHELL']
+        or_ctrld = '' if windows else "or 'Ctrl+D' "
+        sys.stderr.write("Launching subshell in virtual environment. Type "
+                         "'exit' %sto return.\n" % or_ctrld)
+
     # we don't strictly need to restore the environment, since pew runs in
     # its own process, but it feels like the right thing to do
     with temp_environ():
@@ -113,8 +119,8 @@ def inve(env, command, *args, **kwargs):
 
 
 def shell(env, cwd=None):
-    shell = 'powershell' if windows else os.environ['SHELL']
     if not windows:
+        shell = 'powershell' if windows else os.environ['SHELL']
         # On Windows the PATH is usually set with System Utility
         # so we won't worry about trying to check mistakes there
         shell_check = (sys.executable + ' -c "from pew.pew import '
@@ -123,11 +129,8 @@ def shell(env, cwd=None):
             inve(str(env), shell, '-c', shell_check)
         except CalledProcessError:
             return
-    or_ctrld = '' if windows else "or 'Ctrl+D' "
-    sys.stderr.write("Launching subshell in virtual environment. Type "
-                     "'exit' %sto return.\n" % or_ctrld)
 
-    inve(str(env), shell, cwd=cwd)
+    inve(str(env), cwd=cwd)
 
 
 def mkvirtualenv(envname, python=None, packages=[], project=None,

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -134,7 +134,6 @@ def inve(env, command=None, *args, **kwargs):
             # won't inherit the PATH
         except OSError as e:
             if e.errno == 2:
-                print(kwargs)
                 sys.stderr.write("Unable to find %s\n" % command)
             else:
                 raise

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -107,11 +107,10 @@ def inve(env, command=None, *args, **kwargs):
     if kwargs.pop('guard', False) and not windows:
         # On Windows the PATH is usually set with System Utility
         # so we won't worry about trying to check mistakes there
-        shell = 'powershell' if windows else os.environ['SHELL']
         shell_check = (sys.executable + ' -c "from pew.pew import '
                        'prevent_path_errors; prevent_path_errors()"')
         try:
-            inve(str(env), shell, '-c', shell_check)
+            inve(str(env), os.environ['SHELL'], '-c', shell_check)
         except CalledProcessError:
             return
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -139,10 +139,6 @@ def inve(env, command=None, *args, **kwargs):
                 raise
 
 
-def shell(env, **kwargs):
-    inve(str(env), guard=True, **kwargs)
-
-
 def mkvirtualenv(envname, python=None, packages=[], project=None,
                  requirements=None, rest=[]):
 
@@ -193,7 +189,7 @@ project directory to associate with the new environment.')
     mkvirtualenv(args.envname, args.python, args.packages, project,
                  args.requirements, rest)
     if args.activate:
-        shell(args.envname)
+        inve(args.envname, guard=True)
 
 
 def rmvirtualenvs(envs):
@@ -273,7 +269,7 @@ def workon_cmd():
         # Check if the virtualenv has an associated project directory and in
         # this case, use it as the current working directory.
         project_dir = get_project_dir(env) or os.getcwd()
-        shell(env, cwd=project_dir)
+        inve(env, guard=True, cwd=project_dir)
 
 
 def sitepackages_dir():
@@ -375,7 +371,7 @@ def cp_cmd():
     print('Copying {0} in {1}'.format(source, target_name))
     clone_virtualenv(str(source), str(target))
     if args.activate:
-        shell(target_name)
+        inve(target_name, guard=True)
 
 
 def setvirtualenvproject(env, project):
@@ -429,7 +425,7 @@ Create it or set PROJECT_HOME to an existing directory.' % projects_home)
         template = workon_home / ("template_" + template_name)
         inve(args.envname, str(template), args.envname, str(project))
     if args.activate:
-        shell(args.envname, cwd=str(project))
+        inve(args.envname, guard=True, cwd=str(project))
 
 
 def mktmpenv_cmd():
@@ -447,7 +443,7 @@ def mktmpenv_cmd():
     try:
         if args.activate:
             # only used for testing on windows
-            shell(env)
+            inve(env, guard=True)
     finally:
         rmvirtualenvs([env])
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -100,9 +100,7 @@ def inve(env, command=None, *args, **kwargs):
 
     if not command:
         command = 'powershell' if windows else os.environ['SHELL']
-        or_ctrld = '' if windows else "or 'Ctrl+D' "
-        sys.stderr.write("Launching subshell in virtual environment. Type "
-                         "'exit' %sto return.\n" % or_ctrld)
+        sys.stderr.write('Entering {0} with {1}.'.format(env, command))
 
     if kwargs.pop('guard', False) and not windows:
         # On Windows the PATH is usually set with System Utility

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -465,6 +465,9 @@ def in_cmd():
     if len(sys.argv) < 2:
         sys.exit('You must provide a valid virtualenv to target')
 
+    if len(sys.argv) == 2:
+        return workon_cmd()
+
     env = sys.argv[1]
     env_path = workon_home / env
     if not env_path.exists():

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -86,8 +86,7 @@ def unsetenv(key):
     if key in os.environ:
         del os.environ[key]
 
-def inve(env, *args, **kwargs):
-    assert args
+def inve(env, command, *args, **kwargs):
     # we don't strictly need to restore the environment, since pew runs in
     # its own process, but it feels like the right thing to do
     with temp_environ():
@@ -102,13 +101,13 @@ def inve(env, *args, **kwargs):
         unsetenv('__PYVENV_LAUNCHER__')
 
         try:
-            return check_call(args, shell=windows, **kwargs)
+            return check_call([command] + list(args), shell=windows, **kwargs)
             # need to have shell=True on windows, otherwise the PYTHONPATH
             # won't inherit the PATH
         except OSError as e:
             if e.errno == 2:
                 print(kwargs)
-                sys.stderr.write("Unable to find %s\n" % args[0])
+                sys.stderr.write("Unable to find %s\n" % command)
             else:
                 raise
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -118,7 +118,7 @@ def inve(env, command=None, *args, **kwargs):
                 raise
 
 
-def shell(env, cwd=None):
+def shell(env, **kwargs):
     if not windows:
         shell = 'powershell' if windows else os.environ['SHELL']
         # On Windows the PATH is usually set with System Utility
@@ -130,7 +130,7 @@ def shell(env, cwd=None):
         except CalledProcessError:
             return
 
-    inve(str(env), cwd=cwd)
+    inve(str(env), **kwargs)
 
 
 def mkvirtualenv(envname, python=None, packages=[], project=None,

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -107,10 +107,9 @@ def inve(env, command=None, *args, **kwargs):
     if kwargs.pop('guard', False) and not windows:
         # On Windows the PATH is usually set with System Utility
         # so we won't worry about trying to check mistakes there
-        shell_check = (sys.executable + ' -c "from pew.pew import '
-                       'prevent_path_errors; prevent_path_errors()"')
+        check = '{0} -c "import pew.pew; pew.pew.prevent_path_errors()"'
         try:
-            inve(str(env), os.environ['SHELL'], '-c', shell_check)
+            inve(env, os.environ['SHELL'], '-c', check.format(sys.executable))
         except CalledProcessError:
             return
 

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -14,6 +14,13 @@ def test_workon(env1):
     assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='cannot supply stdin to powershell')
+def test_in(env1):
+    cmd = '{0} {1} "{2}"'.format(*check_env)
+    out = invoke('in', 'env1', inp=cmd).out
+    assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
+
+
 def test_in(env1):
     out = invoke('in', 'env1', *check_env).out
     assert 'env1' == os.path.basename(out.splitlines()[-1].strip())


### PR DESCRIPTION
Currently `pew in myvenv` is an invalid command. It makes sense for
it to run a sensible default command in the virtual env, and a
sensible default command would be a subshell. This proxies that
currently invalid command to be the same as `pew workon myvenv`.

This is intentionally minimal to start a discussion. In pew2
(sorry for that terrible name) I liked the idea of having `in`
do all of the subcommands, and deprecating the `workon` command.
That's an approach that I think is worth considering, and that
I'm certainly in favor of.

If this is acceptable, we may wish to do a further refactor to
combine the `inve` and `subshell` functions. I'll do more of that
if we agree that having `pew in` be more polymorphic is a good
idea, and think that we'd like to mirror that in the `inve`
function.