### PR TITLE
Add support for loading environment variables from .inve.ini file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ def env2(workon_home):
     yield
     invoke('rm', 'env2')
 
-
 @pytest.yield_fixture()
 def testpackageenv(workon_home):
     testpackage = str(Path(__file__).parent / 'testpackage')
@@ -51,3 +50,15 @@ def testtemplate(workon_home):
     testtemplatefile.chmod(0o700)
     yield testtemplatefile
     testtemplatefile.unlink()
+
+@pytest.yield_fixture()
+def envwithvar(workon_home):
+    invoke('new', 'envwithvar', '-d')
+    sourceini = Path(__file__).parent / 'test_ini'
+    testinifile = workon_home / 'envwithvar' / '.inve.ini'
+    copy(str(sourceini), str(testinifile))
+    testinifile.chmod(0o700)
+    yield
+    testinifile.unlink()
+    invoke('rm','envwithvar')
+

--- a/tests/test_cp.py
+++ b/tests/test_cp.py
@@ -16,6 +16,12 @@ def copied_env(workon_home, env1):
     yield workon_home / 'destination'
     invoke('rm', 'destination')
 
+@pytest.yield_fixture()
+def copied_var_env(envwithvar):
+    invoke('cp', 'envwithvar','destination','-d')
+    yield
+    invoke ('rm','destination')
+
 
 def test_new_env_activated(workon_home, testpackageenv):
     invoke('cp', 'source', 'destination', '-d')
@@ -48,3 +54,7 @@ def test_source_does_not_exists(workon_home):
 def test_no_global_site_packages(copied_env):
     site = Path(invoke('workon', copied_env.name, inp='pew sitepackages_dir').out)
     assert (site.parent / 'no-global-site-packages.txt').exists
+
+def test_copy_ini_file(copied_var_env):
+    out = invoke('workon', 'destination', inp='echo $TestVariable').out
+    assert 'Present' in out

--- a/tests/test_ini
+++ b/tests/test_ini
@@ -1,0 +1,4 @@
+#test file for processing environment variables in ini files
+[env]
+TestVariable=Present
+

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -30,3 +30,10 @@ def test_no_pew_workon_home(workon_home):
     with temp_environ():
         os.environ['WORKON_HOME'] += '/not_there'
         assert 'does not exist' in invoke('in', 'doesnt_exist').err
+
+def test_var(envwithvar):
+    check_var = [sys.executable, '-c', "import os; print(os.environ['TestVariable'])"]
+    out = invoke('in', 'envwithvar', *check_var).out
+    assert 'Present' in out
+
+


### PR DESCRIPTION
I had a similar use case to Pull Request #36. I reimplemented @rraval's changes against the latest codebase and added some tests.

I'm also interested in adding adding some commands to pew to manage environment variables within a virtualenv. E.g.
pew setvar env1 VariableName VariableValue

