### PR TITLE
Proof of Concept Hooks Implementation

### DIFF
--- a/pew/hooks.py
+++ b/pew/hooks.py
@@ -1,0 +1,43 @@
+import os.path
+
+from importlib.machinery import SOURCE_SUFFIXES, SourceFileLoader
+from pathlib import Path
+
+class _Hook(object):
+    def __init__(self):
+        self._registry = []
+
+    def register(self, priority=float('inf')):
+        def combinator(f):
+            self._registry.append((priority, f))
+            return f
+
+        return combinator
+
+    def call(self, *args, **kwargs):
+        for _, f in sorted(self._registry, key=lambda x: x[0]):
+            f(*args, **kwargs)
+
+def _import_path(path):
+    str_path = str(path)
+    # use the first component of the filename and use that as module name
+    name = 'pew.hooks.{}'.format(os.path.basename(str_path).split('.')[0])
+    loader = SourceFileLoader(name, str_path)
+    return loader.load_module()
+
+def import_hooks(file_or_dir):
+    for suffix in SOURCE_SUFFIXES:
+        path = str(file_or_dir) + suffix
+        if os.path.exists(path):
+            _import_path(path)
+            return
+
+    if os.path.isdir(str(file_or_dir)):
+        for suffix in SOURCE_SUFFIXES:
+            for path in file_or_dir.glob('**/*' + suffix):
+                _import_path(path)
+
+# hooks exposed for downstream
+# FIXME: document purpose of each hook
+preactivate_hook = _Hook()
+postactivate_hook = _Hook()

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -22,6 +22,7 @@ except ImportError:
     pass # setup.py needs to import this before the dependencies are installed
 
 from pew import __version__
+from pew.hooks import import_hooks, preactivate_hook, postactivate_hook
 from pew._utils import (check_call, invoke, expandpath, own,
                         env_bin_dir, check_path, temp_environ)
 from pew._print_utils import print_virtualenvs
@@ -81,6 +82,8 @@ def get_project_dir(env):
 
     return project_dir
 
+def get_hook_location(env):
+    return workon_home / env / '.pew' / 'hooks'
 
 def unsetenv(key):
     if key in os.environ:
@@ -128,7 +131,9 @@ def shell(env, cwd=None):
     sys.stderr.write("Launching subshell in virtual environment. Type "
                      "'exit' %sto return.\n" % or_ctrld)
 
+    preactivate_hook.call()
     inve(str(env), shell, cwd=cwd)
+    postactivate_hook.call()
 
 
 def mkvirtualenv(envname, python=None, packages=[], project=None,
@@ -261,6 +266,7 @@ def workon_cmd():
         # Check if the virtualenv has an associated project directory and in
         # this case, use it as the current working directory.
         project_dir = get_project_dir(env) or os.getcwd()
+        import_hooks(get_hook_location(env))
         shell(env, cwd=project_dir)
 
 


### PR DESCRIPTION
This patch represents what I think the python hooks implementation in pew should look like, putting some code to my thoughts in #46. It's totally experimental, needs support for python 2, unit tests, documentation, and more hook coverage.

First, I think pew should relocate its per virtual environment configuration to `$VIRTUAL_ENV/.pew`. Thankfully, `.project` seems to be the only configuration file at the moment, so we can easily move to `$VIRTUAL_ENV/.pew/project` with a fallback to `$VIRTUAL_ENV/.project` for legacy projects. This patch _DOES NOT_ address the need for ergonomic definition of simple environment variables that need to be injected, but this directory layout can easily help facilitate that.

Second, this patch adds support for hooks to be defined on a per virtual environment basis. A hook is a simple python module, which can either be stored as `$VIRTUAL_ENV/.pew/hooks.py` or as a file under `$VIRTUAL_ENV/.pew/hooks/`.

The hook syntax is fairly ergonomic and offers all the flexibility of python. For example:

``` python
# in $VIRTUAL_ENV/.pew/hooks/low.py
import os
from pew.hooks import preactivate_hook

@preactivate_hook.register()
def low_priority():
    print("Hook with no priority")
    os.environ['LOW_PRIORITY'] = 'low'
```

``` python
# in $VIRTUAL_ENV/.pew/hooks/high.py
import os
from pew.hooks import preactivate_hook, postactivate_hook

@preactivate_hook.register(priority=1)
def other_hook():
    print("Hook with high priority")
    os.environ['HIGH_PRIORITY'] = 'high'

@postactivate_hook.register(priority=1)
def other_hook_post():
    print("Goodbye hook with high priority")
```

These simple definitions lead to the following behaviour:

```
$ pew workon test
Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
Hook with high priority
Hook with no priority
$ echo $LOW_PRIORITY $HIGH_PRIORITY 
low high
$ exit

Goodbye hook with high priority
```
