### PR TITLE
Indicate what to add to the zsh prompt, so that it displays the name of ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,13 @@ To get a blue-colored name at the start of your prompt:
 
 #### zsh prompt ####
 
-Add this at the beginning of your `PS1`
+Add this to your .zshrc file, before your `PS1` declaration :
 
-`%{$fg_bold[blue]%}$(basename "$VIRTUAL_ENV")`
+`venv=$(basename "$VIRTUAL_ENV")`
+
+Then add this at the beginning of your `PS1` :
+
+`%{$fg_bold[blue]%}$venv${venv:+ }`
 
 #### fish prompt ####
 


### PR DESCRIPTION
...the current virtualenv followed by a space, but no space if no virtualenv is active.

The current PS1 addition suggested doesn't add a space after the virtualenv name. You can easily add a space character, but then it's always displayed, even if no virtualenv is active, which leads to a prompt beginning with a space, which looks silly.