### PR TITLE
Workon Home Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Command Reference
 
 Create a new environment, in the WORKON_HOME.
 
-`usage: pew-new [-hd] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] envname`
+`usage: pew-new [-hd] [-w WORKON_HOME] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] envname`
 
 The new environment is automatically activated after being initialized.
 
@@ -131,11 +131,13 @@ The `-i` option can be used to install one or more packages (by repeating the op
 
 The `-r` option can be used to specify a text file listing packages to be installed. The argument value is passed to `pip -r` to be installed.
 
+The `-w` option can be used to specify the `WORKON_HOME` directory, overriding the value specified in the environment variable.
+
 ### workon ###
 
 List or change working virtual environments.
 
-`usage: pew-workon [environment_name]`
+`usage: pew-workon [-w WORKON_HOME] [environment_name]`
 
 If no `environment_name` is given the list of available environments is printed to stdout.
 
@@ -143,13 +145,13 @@ If no `environment_name` is given the list of available environments is printed 
 
 Create a temporary virtualenv.
 
-`usage: pew-mktmpenv [-h] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS]`
+`usage: pew-mktmpenv [-h] [-w WORKON_HOME] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS]`
 
 ### ls ###
 
 List all of the environments.
 
-`usage: pew-ls [-h] [-b | -l]`
+`usage: pew-ls [-h] [-b | -l] [-w WORKON_HOME]`
 
 ### show ###
 
@@ -159,19 +161,19 @@ List all of the environments.
 
 Run a command in each virtualenv.
 
-`usage: pew-inall [command]`
+`usage: pew-inall [-w WORKON_HOME] [command]`
 
 ### in ###
 
 Run a command in the given virtualenv.
 
-`usage: pew-in [env] [command]`
+`usage: pew-in [-w WORKON_HOME] [env] [command]`
 
 ### rm ###
 
 Remove one or more environments, from the WORKON_HOME.
 
-`usage: pew-rm envs [envs ...]`
+`usage: pew-rm [-w WORKON_HOME] envs [envs ...]`
 
 You have to exit from the environment you want to remove.
 
@@ -216,7 +218,7 @@ Controls whether the active virtualenv will access the packages in the global Py
 
 Create a new virtualenv in the `WORKON_HOME` and project directory in `PROJECT_HOME`.
 
-`usage: pew-mkproject [-hd] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] [-t TEMPLATES] [-l] envname`
+`usage: pew-mkproject [-hd] [-w WORKON_HOME] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] [-t TEMPLATES] [-l] envname`
 
 The template option may be repeated to have several templates used to create a new project. The templates are applied in the order named on the command line. All other options are passed to `pew-new` to create a virtual environment with the same name as the project.
 
@@ -226,7 +228,7 @@ A template is simply an executable to be found in `WORKON_HOME`, it will be call
 
 Bind an existing virtualenv to an existing project.
 
-`usage: pew-setproject [virtualenv_path] [project_path]`
+`usage: pew-setproject [-w WORKON_HOME] [virtualenv_path] [project_path]`
 
 When no arguments are given, the current virtualenv and current directory are assumed.
 
@@ -235,7 +237,7 @@ When no arguments are given, the current virtualenv and current directory are as
 Try to restore a broken virtualenv by reinstalling the same python
 version on top of it
 
-`usage: pew-restore env`
+`usage: pew-restore [-w WORKON_HOME] env`
 
 Configuration
 -------------

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -56,8 +56,6 @@ def makedirs_and_symlink_if_needed(workon_home):
                 if e.errno != 17:
                     raise
 
-#makedirs_and_symlink_if_needed(workon_home)
-
 
 inve_site = Path(__file__).parent
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -288,7 +288,7 @@ def workon_cmd():
     env_path = workon_home / args.env
     if not env_path.exists():
         sys.exit("ERROR: Environment '{0}' does not exist. Create it with \
-'pew-new {0}'.".format(env))
+'pew-new {0}'.".format(args.env))
     else:
 
         # Check if the virtualenv has an associated project directory and in

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -165,7 +165,8 @@ requirements file to install a base set of packages into the new environment.')
                         default=True, dest='activate', help="After \
                         creation, continue with the existing shell (don't \
                         activate the new environment).")
-    parser.add_argument('-w','--workon', default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
     return parser
 
 
@@ -176,7 +177,7 @@ def new_cmd():
     parser.add_argument('-a', dest='project', help='Provide a full path to a \
 project directory to associate with the new environment.')
 
-    parser.add_argument('envname')
+    parser.add_argument('envname', help="The name of the virtualenv.")
     args, rest = parser.parse_known_args()
 
     if args.workon:
@@ -209,8 +210,9 @@ def rm_cmd():
     """Remove one or more environment, from $WORKON_HOME."""
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon', default=None)
-    parser.add_argument('env', nargs="+", default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
+    parser.add_argument('env', nargs="+", default=None, help='The name of the virtualenv')
     args = parser.parse_args()
 
     if args.workon:
@@ -256,7 +258,8 @@ def ls_cmd():
     p_group = parser.add_mutually_exclusive_group()
     p_group.add_argument('-b', '--brief', action='store_false')
     p_group.add_argument('-l', '--long', action='store_true')
-    parser.add_argument('-w','--workon', default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
 
     args = parser.parse_args()
 
@@ -271,8 +274,9 @@ def workon_cmd():
     """List or change working virtual environments."""
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon', default=None)
-    parser.add_argument('env', nargs="?", default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
+    parser.add_argument('env', nargs="?", default=None, help='The name of the virtualenv.')
     args = parser.parse_args()
 
     if args.workon:
@@ -314,8 +318,10 @@ directory; if this file does not exists, it will be created first.
     global workon_home
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', dest='remove', action='store_true')
-    parser.add_argument('dirs', nargs='+')
-    parser.add_argument('-w','--workon', default=None)
+    parser.add_argument('dirs', nargs='+', help='Provide a list of \
+                        directories to add to the virtualenv path.')
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
 
     args = parser.parse_args()
     
@@ -384,7 +390,8 @@ def cp_cmd():
                         default=True, dest='activate', help="After \
                         creation, continue with the existing shell (don't \
                         activate the new environment).")
-    parser.add_argument('-w','--workon', default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
 
     args = parser.parse_args()
     
@@ -422,9 +429,12 @@ def setproject_cmd():
 
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon', default=None)
-    parser.add_argument('virtualenv_path', nargs='?', default=None)
-    parser.add_argument('project_path', nargs="?", default=None)
+    parser.add_argument('-w','--workon', default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
+    parser.add_argument('virtualenv_path', nargs='?', default=None,
+                        help='The path to the virtualenv.')
+    parser.add_argument('project_path', nargs="?", default=None,
+                        help='The path to the project directory.')
     args = parser.parse_args()
 
     if args.workon:
@@ -447,7 +457,8 @@ def mkproject_cmd():
 
     global workon_home
     parser = mkvirtualenv_argparser()
-    parser.add_argument('envname', nargs="?")
+    parser.add_argument('envname', nargs="?", help='The name of the \
+                        virtualenv.')
     parser.add_argument(
         '-t', action='append', default=[], dest='templates', help='Multiple \
 templates may be selected.  They are applied in the order specified on the \
@@ -532,7 +543,8 @@ def inall_cmd():
 
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon',default=None)
+    parser.add_argument('-w','--workon',default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
     args, rest = parser.parse_known_args()
 
     if args.workon:
@@ -550,8 +562,9 @@ def in_cmd():
 
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon',default=None)
-    parser.add_argument('env')
+    parser.add_argument('-w','--workon',default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
+    parser.add_argument('env', help='The name of the virtualenv.')
     args, rest = parser.parse_known_args()
 
     if args.workon:
@@ -571,8 +584,9 @@ def restore_cmd():
 
     global workon_home
     parser = argparse.ArgumentParser()
-    parser.add_argument('-w','--workon',default=None)
-    parser.add_argument('env')
+    parser.add_argument('-w','--workon',default=None, help='Specify an \
+                        alternative WORKON_HOME folder.')
+    parser.add_argument('env', help='The name of the virtualenv.')
     args = parser.parse_args()
     if args.workon:
         workon_home = expandpath(args.workon)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,18 @@ def workon_home():
     rmtree(str(workon))
 
 
+@pytest.yield_fixture(scope='session')
+def workon_alt():
+    tmpdir = os.environ.get('TMPDIR', gettempdir())
+    os.environ['WORKON_HOME'] = str(Path(tmpdir) / 'WORKON_ALT')
+
+    workon = Path(tmpdir) / 'WORKON_ALT'
+    rmtree(str(workon), ignore_errors=True)
+    workon.mkdir(parents=True)
+    yield workon
+    rmtree(str(workon))
+
+
 @pytest.yield_fixture()
 def env1(workon_home):
     invoke('new', 'env1', '-d')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ def workon_home():
 @pytest.yield_fixture(scope='session')
 def workon_alt():
     tmpdir = os.environ.get('TMPDIR', gettempdir())
-    os.environ['WORKON_HOME'] = str(Path(tmpdir) / 'WORKON_ALT')
 
     workon = Path(tmpdir) / 'WORKON_ALT'
     rmtree(str(workon), ignore_errors=True)

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -23,3 +23,11 @@ def test_lssitepackages_add(workon_home):
     pkgs = invoke('in', 'env', 'pew', 'lssitepackages').out
     assert str(Path('.').absolute()) in pkgs
     invoke('rm', 'env')
+
+
+def test_ls_alt(workon_alt):
+    invoke('new','alt','-w',str(workon_alt))
+    envs = invoke('ls','-w',str(workon_alt)).out
+    assert 'alt' in envs
+    invoke('rm','alt','-w',str(workon_alt))
+

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -26,7 +26,7 @@ def test_lssitepackages_add(workon_home):
 
 
 def test_ls_alt(workon_alt):
-    invoke('new','alt','-w',str(workon_alt))
+    invoke('new','alt','-w',str(workon_alt),'-d')
     envs = invoke('ls','-w',str(workon_alt)).out
     assert 'alt' in envs
     invoke('rm','alt','-w',str(workon_alt))

--- a/tests/test_mktmpenv.py
+++ b/tests/test_mktmpenv.py
@@ -34,3 +34,8 @@ def test_mktmpenv_autodeletes(workon_home):
     invoke('mktmpenv', '-d' if platform == 'win32' else '')
     envs2 = set(invoke('ls').out.split())
     assert envs == envs2
+
+@skip_windows
+def test_mktmpenv_workon_alt(workon_alt):
+    out = invoke('mktmpenv', '-w', str(workon_alt), inp="python -c 'import os; print(os.environ[\'WORKON_HOME\'])").out
+    assert str(workon_alt) in out

--- a/tests/test_mktmpenv.py
+++ b/tests/test_mktmpenv.py
@@ -37,5 +37,5 @@ def test_mktmpenv_autodeletes(workon_home):
 
 @skip_windows
 def test_mktmpenv_workon_alt(workon_alt):
-    out = invoke('mktmpenv', '-w', str(workon_alt), inp="python -c 'import os; print(os.environ[\'WORKON_HOME\'])").out
+    out = invoke('mktmpenv', '-w', str(workon_alt), inp="""python -c 'import os; print(os.environ["VIRTUAL_ENV"])'""").out
     assert str(workon_alt) in out

--- a/tests/test_mkvirtualenv.py
+++ b/tests/test_mkvirtualenv.py
@@ -83,3 +83,11 @@ def test_requirements_file(workon_home):
         assert 'IPy' in freeze
         invoke('rm', 'env')
         unlink(temp.name)
+
+def test_create_alt(workon_home, workon_alt):
+    invoke('new', 'alt', '-d', '-w' str(workon_alt))
+    envs = set(invoke('ls').out.split())
+    envs1 = set(invoke('ls').out.split())
+    invoke('rm', 'alt', '-w', str(workon_alt))
+    assert 'alt' not in envs
+    assert 'alt' in envs1

--- a/tests/test_mkvirtualenv.py
+++ b/tests/test_mkvirtualenv.py
@@ -87,7 +87,7 @@ def test_requirements_file(workon_home):
 def test_create_alt(workon_home, workon_alt):
     invoke('new', 'alt', '-d', '-w', str(workon_alt))
     envs = set(invoke('ls').out.split())
-    envs1 = set(invoke('ls').out.split())
+    envs1 = set(invoke('ls','-w',str(workon_alt)).out.split())
     invoke('rm', 'alt', '-w', str(workon_alt))
     assert 'alt' not in envs
     assert 'alt' in envs1

--- a/tests/test_mkvirtualenv.py
+++ b/tests/test_mkvirtualenv.py
@@ -85,7 +85,7 @@ def test_requirements_file(workon_home):
         unlink(temp.name)
 
 def test_create_alt(workon_home, workon_alt):
-    invoke('new', 'alt', '-d', '-w' str(workon_alt))
+    invoke('new', 'alt', '-d', '-w', str(workon_alt))
     envs = set(invoke('ls').out.split())
     envs1 = set(invoke('ls').out.split())
     invoke('rm', 'alt', '-w', str(workon_alt))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -80,3 +80,12 @@ def test_apply_template(project_home, testtemplate):
         assert projname in f.read()
     invoke('rm', projname)
     rmtree(str(project_home / projname))
+
+def test_mkproject_alt(workon_alt, project_home):
+    projname = 'project1'
+    invoke('mkproject', projname, '-d', '-w', str(workon_alt))
+    envs = invoke('ls','-w',str(workon_alt)).out
+    assert projname in envs
+    invoke('rm', projname)
+    rmtree(str(project_home / projname))
+

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -12,3 +12,17 @@ def test_restore(workon_home, env1):
     invoke('restore', 'env1')
     result = invoke('in', 'env1', 'python','-vc', '')
     assert 'Error' not in result.err and 'fail' not in result.err
+
+
+def test_restore(workon_alt):
+    patterns = ['lib*/*/site.py*', 'Lib/site.py*']
+    invoke('new','env1','-d','-w',str(workon_alt))
+    to_be_deleted = set(chain(*((workon_alt / 'env1').glob(pat) for pat in patterns)))
+    for site in to_be_deleted:
+        site.unlink()
+    result = invoke('in', '-w', str(workon_alt), 'env1', 'python', '-vc', '')
+    assert 'Error' in result.err or 'fail' in result.err
+    invoke('restore', 'env1', '-w', str(workon_alt))
+    result = invoke('in', '-w', str(workon_alt), 'env1', 'python','-vc', '')
+    assert 'Error' not in result.err and 'fail' not in result.err
+    invoke('rm','-w', str(workon_alt), 'env1')

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -14,7 +14,7 @@ def test_restore(workon_home, env1):
     assert 'Error' not in result.err and 'fail' not in result.err
 
 
-def test_restore(workon_alt):
+def test_restore_alt(workon_alt):
     patterns = ['lib*/*/site.py*', 'Lib/site.py*']
     invoke('new','env1','-d','-w',str(workon_alt))
     to_be_deleted = set(chain(*((workon_alt / 'env1').glob(pat) for pat in patterns)))

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -15,8 +15,8 @@ def test_restore(workon_home, env1):
 
 
 def test_restore_alt(workon_alt):
-    patterns = ['lib*/*/site.py*', 'Lib/site.py*']
     invoke('new','env1','-d','-w',str(workon_alt))
+    patterns = ['lib*/*/site.py*', 'Lib/site.py*']
     to_be_deleted = set(chain(*((workon_alt / 'env1').glob(pat) for pat in patterns)))
     for site in to_be_deleted:
         site.unlink()

--- a/tests/test_rmvirtualenv.py
+++ b/tests/test_rmvirtualenv.py
@@ -22,7 +22,7 @@ def test_no_such_env(workon_home):
     check_call('pew rm not_here'.split())
 
 def test_remove_alt(workon_alt):
-	invoke('new','delete_this','-w',str(workon_alt),'-d')
+    invoke('new','delete_this','-w',str(workon_alt),'-d')
     envs = invoke('ls','-w',str(workon_alt)).out
     assert 'delete_this' in envs
     invoke('rm','delete_this','-w',str(workon_alt))

--- a/tests/test_rmvirtualenv.py
+++ b/tests/test_rmvirtualenv.py
@@ -20,3 +20,11 @@ def test_remove(to_be_deleted):
 def test_no_such_env(workon_home):
     assert not (workon_home / 'not_here').exists()
     check_call('pew rm not_here'.split())
+
+def test_remove_alt(workon_alt):
+	invoke('new','delete_this','-w',str(workon_alt),'-d')
+    envs = invoke('ls','-w',str(workon_alt)).out
+    assert 'delete_this' in envs
+    invoke('rm','delete_this','-w',str(workon_alt))
+    envs = invoke('ls','-w',str(workon_alt)).out
+    assert 'delete_this' not in envs

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -35,7 +35,7 @@ def test_no_pew_workon_home(workon_home):
 def test_workon_alt(workon_alt):
     invoke('new','-w',str(workon_alt),'env1','-d')
     cmd = '{0} {1} "{2}"'.format(*check_env)
-    out = invoke('workon', 'env1', '-w', str(workon_alr), inp=cmd).out
+    out = invoke('workon', 'env1', '-w', str(workon_alt), inp=cmd).out
     assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
     invoke('rm','-w',str(workon_alt))
 

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -30,3 +30,12 @@ def test_no_pew_workon_home(workon_home):
     with temp_environ():
         os.environ['WORKON_HOME'] += '/not_there'
         assert 'does not exist' in invoke('in', 'doesnt_exist').err
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='cannot supply stdin to powershell')
+def test_workon_alt(workon_alt):
+    invoke('new','-w',str(workon_alt),'env1','-d')
+    cmd = '{0} {1} "{2}"'.format(*check_env)
+    out = invoke('workon', 'env1', '-w', str(workon_alr), inp=cmd).out
+    assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
+    invoke('rm','-w',str(workon_alt))
+


### PR DESCRIPTION
I found myself often writing scripts that would first `export WORKON_HOME=...` and then `pew in ...` and I thought it might be useful to "combine" the two.

I've implemented a `--workon` flag to several of the pew commands that allows the user to specify a directory that will be used in place of WORKON_HOME. In doing so I also changed how a handful of commands read command line parameters. Specifically, by changing them to use `argparse` if they weren't already.