### PR TITLE
Wraps reset marker in '\[\]'

### DIFF
--- a/pew/shell_config/init.bash
+++ b/pew/shell_config/init.bash
@@ -1,3 +1,3 @@
 source "$( dirname "${BASH_SOURCE[0]}" )"/complete.bash
 
-PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\e[0m$PS1"
+PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\[\e[0m\]$PS1"


### PR DESCRIPTION
The final reset marker `\e[0m` is not wrapped in `\[\]` which leads to issues in prompt size computation. This introduce unpredictible behaviors, e.g., when the input is near the end of the line (see picture below):

![issue](https://cloud.githubusercontent.com/assets/2317394/12961039/bd261354-d03e-11e5-87ed-2d4bd2576613.png)

The issue had been observed with:

* xterm
* terminology

The fix had been tested with:

* xterm
* terminology
