### PR TITLE
Pathfinder

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -198,8 +198,9 @@ def locate_python_by_version(version, pytype):
     pkg = Package(version, pytype)
     if is_installed(pkg):
         for bin in ('python3', 'python', 'pypy3', 'pypy'):
-            path = os.path.join(PATH_PYTHONS, pkg.name, 'bin', bin)
-            if os.path.exists(path):
+            guess = os.path.join(PATH_PYTHONS, pkg.name, 'bin', bin)
+            if os.path.exists(guess):
+                path = guess
                 break
     return path
 


### PR DESCRIPTION
This is an attempt to save the user a little typing when creating a new virtualenv or project. Instead of typing:

```bash
> pew new -p $(pew locate_python 3.5.1) venv
```

the user can just type:

```bash
> pew new -p 3.5.1 venv
```

I tried to be as unobtrusive as possible -- the new code should be completely backwards compatible. The old style is still supported, and it shouldn't break anything on Windows.

Unfortunately I wasn't able to simply call into Pythonz's functionality to find the path, because instead of returning the path as a string, it prints the path to STDOUT directly and returns None. Capturing STDOUT proved to be too messy and fragile, but the relevant code in Pythonz is short and straightforward, so I adapted it for this purpose in a new function, `locate_python_by_version`.

I also added a few tests, trying to stick to the style of your existing tests.

Hopefully you agree that this is a useful feature. If you want me to revisit the implementation or find bugs/regressions, let me know.

Cheers, and thanks for making Pew!