### PR TITLE
Bugfix: pew in/workon /absolute/path (fix: #108)

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -309,6 +309,8 @@ def workon_cmd(argv):
         lsvirtualenv(False)
         return
 
+    if env.startswith('/'):
+        sys.exit("ERROR: Invalid environment name '{0}'.".format(env))
     env_path = workon_home / env
     if not env_path.exists():
         sys.exit("ERROR: Environment '{0}' does not exist. Create it with \
@@ -568,6 +570,8 @@ def in_cmd(argv):
         return workon_cmd(argv)
 
     env = argv[0]
+    if env.startswith('/'):
+        sys.exit("ERROR: Invalid environment name '{0}'.".format(env))
     if not (workon_home / env).exists():
         sys.exit("ERROR: Environment '{0}' does not exist. Create it with \
 'pew new {0}'.".format(env))

--- a/tests/test_in.py
+++ b/tests/test_in.py
@@ -1,0 +1,14 @@
+import os
+
+from pew._utils import temp_environ, invoke_pew as invoke
+
+
+def test_no_pew_in_home(workon_home):
+    with temp_environ():
+        os.environ['WORKON_HOME'] += '/not_there'
+        assert 'does not exist' in invoke('in', 'doesnt_exist').err
+
+
+def test_invalid_pew_workon_env_name(workon_home):
+    with temp_environ():
+        assert 'Invalid environment' in invoke('in', '/home/toto').err

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @skip_windows(reason='Pythonz is unsupported')
-@pytest.mark.skipif(sys.version_info > (2,7) and os.environ.get('CI') == 'true',
+@pytest.mark.skipif(sys.platform == 'cygwin' or (sys.version_info > (2,7) and os.environ.get('CI') == 'true'),
                     reason='Limit this slow and expensive test to the oldest '
                     'Python version in the CI environment')
 def test_install():

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -32,4 +32,9 @@ def test_no_symlink(env1):
 def test_no_pew_workon_home(workon_home):
     with temp_environ():
         os.environ['WORKON_HOME'] += '/not_there'
-        assert 'does not exist' in invoke('in', 'doesnt_exist').err
+        assert 'does not exist' in invoke('workon', 'doesnt_exist').err
+
+
+def test_invalid_pew_workon_env_name(workon_home):
+    with temp_environ():
+        assert 'Invalid environment' in invoke('workon', '/home/toto').err


### PR DESCRIPTION
This fixes `in` & `workon` commands,
but I suspect this issue can arise in many other places:
```bash
$ grep '/ env' pew/pew.py
    project_file = workon_home / env / '.project'
    envdir = workon_home / env
        str(envdir / env_bin_dir),
        os.environ['VIRTUAL_ENV'] = str(workon_home / env)
        env = workon_home / env
    env_python = workon_home / env / env_bin_dir / 'python'
    env_path = workon_home / env
        env_python = workon_home / env / env_bin_dir / 'python'
    with (workon_home / env / '.project').open('wb') as prj:
    if not (workon_home / env).exists():
    while (workon_home / env).exists():
    elif not (workon_home / env).exists():
        env_pip = str(workon_home / env / env_bin_dir / 'pip')
    if not (workon_home / env).exists():
    py = workon_home / env / env_bin_dir / ('python.exe' if windows else 'python')
```