### PR TITLE
Update init.bash

### DIFF
--- a/pew/shell_config/init.bash
+++ b/pew/shell_config/init.bash
@@ -1,3 +1,3 @@
 source "$( dirname "${BASH_SOURCE[0]}" )"/complete.bash
 
-PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\e[0m$PS1"
+PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\[\e[0m\]$PS1"


### PR DESCRIPTION
the color cancelling code should be length calculating escaped, otherwise will cause prompt length error when ctrl-a / ctrl-e.