### PR TITLE
allow source command indentation in shell rc

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -639,7 +639,7 @@ def first_run_setup():
                            , 'zsh': '~/.zshrc'
                            , 'fish': '~/.config/fish/config.fish'}[shell])
         with rcpath.open('r+') as rcfile:
-            if (source_cmd + '\n') not in rcfile.readlines():
+            if source_cmd not in (line.strip() for line in rcfile.readlines()):
                 choice = 'X'
                 while choice not in ('y', '', 'n'):
                     choice = input("It seems that you're running pew for the first time\n"


### PR DESCRIPTION
Improve the `source_cmd` check to also validate indented source command like:

    # pew - python env wrapper
    if type -q pew
        source (pew shell_config)
    end