### PR TITLE
Remove unnecessary shebang

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 from __future__ import print_function, absolute_import, unicode_literals
 
 import os


### PR DESCRIPTION
This file is not exectuable, and even if it were it doesn't do anything
useful when executed on its own.

This came up in the review to include pew in Fedora.