### PR TITLE
Fix IndexError when calling "workon" with no argument, #137.

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -348,7 +348,12 @@ def parse_envname(argv, no_arg_callback):
 
 def workon_cmd(argv):
     """List or change working virtual environments."""
-    env = parse_envname(argv, lambda: lsvirtualenv(False))
+
+    def list_and_exit():
+        lsvirtualenv(False)
+        sys.exit(0)
+
+    env = parse_envname(argv, list_and_exit)
 
     # Check if the virtualenv has an associated project directory and in
     # this case, use it as the current working directory.

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -16,7 +16,6 @@ def test_workon(env1):
     assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
 
 
-@pytest.mark.xfail
 def test_workon_no_arg(env1, env2):
     result = invoke('workon')
     out = result.out

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -4,6 +4,7 @@ import sys
 from pew._utils import temp_environ, invoke_pew as invoke
 from utils import skip_windows
 
+import pytest
 
 check_env = [sys.executable, '-c', "import os; print(os.environ['VIRTUAL_ENV'])"]
 
@@ -13,6 +14,17 @@ def test_workon(env1):
     cmd = '{0} {1} "{2}"'.format(*check_env)
     out = invoke('workon', 'env1', inp=cmd).out
     assert 'env1' == os.path.basename(out.splitlines()[-1].strip())
+
+
+@pytest.mark.xfail
+def test_workon_no_arg(env1, env2):
+    result = invoke('workon')
+    out = result.out
+    envs = [ x.strip() for x in out.split() ]
+
+    assert 0 == result.returncode
+    assert 'env1' in envs
+    assert 'env2' in envs
 
 
 @skip_windows(reason='cannot supply stdin to powershell')


### PR DESCRIPTION
Eventually, I think it would be better for `parse_envname()` to just raise `KeyError` or similar, in which case we could `lsvirtualenv()` or err out appropriately.  Passing the `no_arg_callback` seems strange.

However, this at least fixes the immediate issue.  Includes basic unit test.