### PR TITLE
Fix virtualenv creation when WORKON_HOME lives within a symlink dir

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -211,8 +211,10 @@ def mkvirtualenv(envname, python=None, packages=[], project=None,
     if python:
         rest = ["--python=%s" % python] + rest
 
+    path = (workon_home / envname).absolute()
+
     try:
-        check_call(["virtualenv", envname] + rest, cwd=str(workon_home))
+        check_call(["virtualenv", str(path)] + rest)
     except (CalledProcessError, KeyboardInterrupt):
         rmvirtualenvs([envname])
         raise
@@ -611,10 +613,11 @@ def restore_cmd(argv):
         sys.exit('You must provide a valid virtualenv to target')
 
     env = argv[0]
-    py = workon_home / env / env_bin_dir / ('python.exe' if windows else 'python')
+    path = workon_home / env
+    py = path / env_bin_dir / ('python.exe' if windows else 'python')
     exact_py = py.resolve().name
 
-    check_call(["virtualenv", env, "--python=%s" % exact_py], cwd=str(workon_home))
+    check_call(["virtualenv", str(path.absolute()), "--python=%s" % exact_py])
 
 
 def dir_cmd(argv):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,34 @@ def workon_home():
 
 
 @pytest.yield_fixture()
+def workon_sym_home():
+    # workon_home() fixture assumes it is the only one changing the environ
+    # so save it and restore it after the test
+    old_workon = os.environ.get('WORKON_HOME', '')
+
+    tmpdir = os.environ.get('TMPDIR', gettempdir())
+    tmpdir = Path(tmpdir) / 'pew-test-tmp'
+
+    # Create the real root and a symlink to it: SYM_ROOT -> REAL_ROOT
+    real_root = tmpdir / 'REAL_ROOT'
+    sym_root = tmpdir / 'SYM_ROOT'
+
+    real_home = real_root / 'WORKON_HOME'
+    real_home.mkdir(parents=True)
+
+    sym_root.symlink_to(real_root, target_is_directory=True)
+    sym_home = sym_root / 'WORKON_HOME'
+
+    # New WORKON_HOME lives in the symlinked root
+    os.environ['WORKON_HOME'] = str(sym_home)
+
+    workon = Path(os.environ['WORKON_HOME'])
+    yield workon
+    rmtree(str(tmpdir))
+    os.environ['WORKON_HOME'] = old_workon
+
+
+@pytest.yield_fixture()
 def env1(workon_home):
     invoke('new', 'env1', '-d')
     yield

--- a/tests/test_mkvirtualenv.py
+++ b/tests/test_mkvirtualenv.py
@@ -12,6 +12,7 @@ except ImportError:
 import pytest
 
 from pew._utils import invoke_pew as invoke
+from utils import skip_windows
 
 
 def are_we_connected():
@@ -32,6 +33,16 @@ def test_create(workon_home):
     envs2 = set(invoke('in', 'env', 'pew', 'ls').out.split())
     invoke('rm', 'env')
     assert envs < envs2
+
+
+@skip_windows(reason="symlinks on windows are not well supported")
+def test_create_in_symlink(workon_sym_home):
+    invoke('new', 'env', '-d')
+    pip_path = Path(invoke('in', 'env', 'which', 'pip').out)
+    with pip_path.open() as f:
+        pip_shebang = f.readline()
+    # check it is using the symlinked path, not the real path
+    assert str(workon_sym_home) in pip_shebang
 
 
 def test_no_args(workon_home):


### PR DESCRIPTION
For creating virtualenvs, pew used to cd into `WORKON_HOME` and then invoke `virtualenv`. If `WORKON_HOME` happens to be in a symlinked directory, the path resolution will consider the real path, not the symlinked one. If the symlink target changes at a later time, all the shebangs that use the real path, which is now obsolete, will be broken.

Eg. if `WORKON_HOME` is `/home/user/.local/venvs` and `/home/user/.local` is a symlink to `/opt/local`,
then current pew will create the virtualenv with `/opt/local` as the root, thus creating scripts with `#!/opt/local/venvs/foo/bin/python` instead of `#!/home/user/.local/venvs/foo/bin/python`

Before:

    >>> check_call(['virtualenv', 'foo'], cwd='/home/user/.local/venvs')
    New python executable in /opt/local/venvs/foo/bin/python

This patch changes the `check_call()` for virtualenv to *not* cd anywhere and instead passes the absolute (but *not* resolved/real) path to the virtualenv home (eg. `/home/user/.local/venvs/foo`).

After:

    >>> check_call(['virtualenv', '/home/user/.local/venvs/foo'])
    # New python executable in /home/user/.local/venvs/foo/bin/python