### PR TITLE
Windows fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ name = "pypi"
 virtualenv = "==1.11.6"
 "virtualenv-clone" = "==0.2.5"
 "pythonz-bd" = "==1.11.2"
+"psutil" = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,8 @@ name = "pypi"
 
 virtualenv = "==1.11.6"
 "virtualenv-clone" = "==0.2.5"
-"pythonz-bd" = "==1.11.2"
-"psutil" = "*"
+"pythonz-bd" = {"version" = "*", "sys_platform" = "!='win32'" }
+"psutil" = {"version" = "*", "sys_platform" = "=='win32'" }
 
 [dev-packages]
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -36,6 +36,8 @@ else:
     InstallCommand = ListPythons = LocatePython = UninstallCommand = \
         lambda : sys.exit('Command not supported on this platform')
 
+    import psutil
+
 from pew import __version__
 from pew._utils import (check_call, invoke, expandpath, own, env_bin_dir,
                         check_path, temp_environ, NamedTemporaryFile, to_unicode)
@@ -183,8 +185,7 @@ def _detect_shell():
         if 'CMDER_ROOT' in os.environ:
             shell = 'Cmder'
         elif windows:
-            parent_pid = os.getppid()
-            shell = invoke('tasklist', '/fi', 'PID eq {}'.format(parent_pid), '/fo', 'csv', '/nh').out.strip()
+            shell = psutil.Process(os.getppid()).parent().name()
         else:
             shell = 'sh'
     return shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ virtualenv==1.11.6
 virtualenv-clone==0.2.5
 pytest==2.6.2
 pythonz-bd==1.11.2
-delegator.py==0.0.13
+psutil==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ setuptools>=17.1
 virtualenv==1.11.6
 virtualenv-clone==0.2.5
 pytest==2.6.2
-pythonz-bd==1.11.2
-psutil==5.3.1
+pythonz-bd==1.11.2 ; sys_platform != 'win32'
+psutil==5.3.1 ; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT License',
     packages=['pew'],
     install_requires=[
-        'virtualenv>=1.11', 'virtualenv-clone>=0.2.5', 'setuptools>=17.1'
+        'virtualenv>=1.11', 'virtualenv-clone>=0.2.5', 'setuptools>=17.1', 'psutil==5.3.1'
     ],
     extras_require={
         ':python_version=="2.6"': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT License',
     packages=['pew'],
     install_requires=[
-        'virtualenv>=1.11', 'virtualenv-clone>=0.2.5', 'setuptools>=17.1', 'psutil==5.3.1'
+        'virtualenv>=1.11', 'virtualenv-clone>=0.2.5', 'setuptools>=17.1'
     ],
     extras_require={
         ':python_version=="2.6"': [
@@ -37,6 +37,9 @@ setup(
         ],
         ':python_version=="3.3"': [
             'pathlib'
+        ],
+        ':sys_platform=="win32"': [
+            'psutil==5.3.1'
         ],
         'pythonz': [
             'pythonz-bd>=1.10.2'


### PR DESCRIPTION
So the tasklist method of looking up the parent id's name works only if the python executable runs the script directly, but since this is a cli util, `pew.exe` is the parent process, not the shell.  The shell is the grandparent of the `pew.exe`.  I also realized that `os.getppid()` doesn't work on windows on 2.x however there is a package, `psutil` that can help us out!  I can have it get the parent id of the `pew.exe` executable and it offers a polyfill for `os.getppid()` for python 2.7.  I've also made it so that it only gets installed on windows machines not any, since it only gets imported and used in windows.