### PR TITLE
Python 2.x compat for Windows shell detection

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -185,7 +185,7 @@ def _detect_shell():
         if 'CMDER_ROOT' in os.environ:
             shell = 'Cmder'
         elif windows:
-            shell = psutil.Process(os.getppid()).parent().name()
+            shell = psutil.Process(os.getpid()).parent().parent().name()
         else:
             shell = 'sh'
     return shell


### PR DESCRIPTION
Python 2.x on Windows does not have os.getppid(), use os.getpid() and psutil instead.