### PR TITLE
Defer pkg_resources import

### DIFF
--- a/pew/__init__.py
+++ b/pew/__init__.py
@@ -1,12 +1,4 @@
-from __future__ import absolute_import, print_function
-import pkg_resources
-import sys
-
-try:
-    __version__ = pkg_resources.get_distribution('pew').version
-except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
-    print('Setuptools has some issues here, failed to get our own package.', file=sys.stderr)
+from __future__ import absolute_import
 
 from . import pew
 __all__ = ['pew']

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -38,7 +38,6 @@ else:
 
     import psutil
 
-from pew import __version__
 from pew._utils import (check_call, invoke, expandpath, own, env_bin_dir,
                         check_path, temp_environ, NamedTemporaryFile, to_unicode)
 from pew._print_utils import print_virtualenvs
@@ -673,6 +672,14 @@ def locate_python_cmd(argv):
 
 def version_cmd(argv):
     """Prints current pew version"""
+    import pkg_resources
+
+    try:
+        __version__ = pkg_resources.get_distribution('pew').version
+    except pkg_resources.DistributionNotFound:
+        __version__ = 'unknown'
+        print('Setuptools has some issues here, failed to get our own package.', file=sys.stderr)
+
     print(__version__)
 
 


### PR DESCRIPTION
This looks a little silly. What's happening here is that `pkg_resources` is quite slow to import – something like 200 ms or more on my system. This makes `pew in` feel sluggish when running commands that should be quick.

This PR takes the most direct approach of moving the `pkg_resources` import into the version command, which is the only consumer.

We could also switch `setup.py` to use a regex to read from `pew/__init__.py`, as many other packages do, if you would prefer that.