### PR TITLE
Use -m to run virtualenv in tests as well

### DIFF
--- a/tests/test_cp.py
+++ b/tests/test_cp.py
@@ -1,4 +1,4 @@
-from sys import platform
+from sys import platform, executable
 from subprocess import check_call
 from pathlib import Path
 
@@ -39,7 +39,8 @@ def test_virtualenv_variable(copied_env):
 
 @xfail_nix
 def test_source_relocatable(workon_home, testpackageenv):
-    check_call(['virtualenv', '--relocatable', str(workon_home / 'source')])
+    check_call([executable, '-m', 'virtualenv', '--relocatable',
+                str(workon_home / 'source')])
     invoke('cp', 'source', 'destination', '-d')
     testscript = Path(invoke('workon', 'destination', inp='which testscript.py').out.strip())
     assert workon_home / 'destination' / 'bin' / 'testscript.py' == testscript


### PR DESCRIPTION
Execution of virtualenv was  changed  to "python -m" style in https://github.com/berdario/pew/commit/999674cdf4e6e82758b4c8e97abf28e1ed5780bd, it would be nice to do the same in tests to keep it consistent.