### PR TITLE
Ignore FileNotFoundError in case to_be_deleted set in test_restore

### DIFF
--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -7,7 +7,10 @@ def test_restore(workon_home, env1):
     patterns = ['lib*/*/site.py*', 'Lib/site.py*']
     to_be_deleted = set(chain(*((workon_home / 'env1').glob(pat) for pat in patterns)))
     for site in to_be_deleted:
-        site.unlink()
+        try:
+            site.unlink()
+        except FileNotFoundError:
+            pass
     result = invoke('in', 'env1', 'python', '-vc', '')
     assert 'Error' in result.err or 'fail' in result.err
     invoke('restore', 'env1')


### PR DESCRIPTION
On Fedora it is common that `/tmp/WORKON_HOME/env1/lib64/` is a symlink to `/tmp/WORKON_HOME/env1/lib/`.
In case 
```
/tmp/WORKON_HOME/env1/lib/python3.6/site.py and
/tmp/WORKON_HOME/env1/lib64/python3.6/site.py
```
appear in `to_be_deleted_set`, file is removed when unlink() is called for the first time and `test_restore` fails in the second iteration with `FileNotFoundError.` I think this can be safely ignored. 