### PR TITLE
Add --here option for pew workon to prevent current directory to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ The `-r` option can be used to specify a text file listing packages to be instal
 
 List or change working virtual environments.
 
-`usage: pew workon [environment_name]`
+`usage: pew workon [environment_name] [--here]`
 
-If no `environment_name` is given the list of available environments is printed to stdout.
+If no `environment_name` is given the list of available environments is printed to stdout. If `--here` is provided, current directory is not changed even if a project path is associated with `environment_name`.
 
 ### mktmpenv ###
 
@@ -434,6 +434,7 @@ Everyone who submitted patches/PR, as of September 2015:
 - Robin
 - Matei Trușcă
 - Lucas Cimon
+- Alexandre Decan
 
 
 Thanks also to Michael F. Lamb for his thought provoking gist and to Doug Hellman for virtualenvwrapper

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -364,7 +364,10 @@ def workon_cmd(argv):
 
     # Check if the virtualenv has an associated project directory and in
     # this case, use it as the current working directory.
-    project_dir = get_project_dir(env) or os.getcwd()
+    project_dir = get_project_dir(env)
+    if project_dir is None or argv[-1] == '--here':
+        project_dir = os.getcwd()
+    
     shell(env, cwd=project_dir)
 
 


### PR DESCRIPTION
This PR implements #179. 

It adds an optional argument for ``pew workon`` (``--here``) that prevents the current directory to be changed. 