### PR TITLE
Put a space after VIRTUAL_ENV basename

### DIFF
--- a/pew/shell_config/init.bash
+++ b/pew/shell_config/init.bash
@@ -1,3 +1,3 @@
 source "$( dirname "${BASH_SOURCE[0]}" )"/complete.bash
 
-PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\[\e[0m\]$PS1"
+[[ -z "${VIRTUAL_ENV}" ]] || PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\[\e[0m\] $PS1"


### PR DESCRIPTION
Before:
VEhost ~ $

After:
VE host ~ $