### PR TITLE
Fix virtualenv list wrapping with long env names

### DIFF
--- a/pew/_print_utils.py
+++ b/pew/_print_utils.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 import os
+from functools import partial
 from math import ceil
 try:
     from itertools import zip_longest
@@ -27,10 +28,12 @@ def row_len(names):
 
 def get_best_columns_number(venvs):
     max_width, _ = get_terminal_size()
+    longest = partial(max, key=len)
     columns_number = 1
     for columns_number in range(1, len(venvs) + 1):
         rows = get_rows(venvs, columns_number)
-        if max(map(row_len, rows)) > max_width:
+        longest_row = list(map(longest, zip_longest(*rows, fillvalue='')))
+        if row_len(longest_row) > max_width:
             return (columns_number - 1) or 1
     else:
         return columns_number

--- a/tests/test_print_utils.py
+++ b/tests/test_print_utils.py
@@ -63,3 +63,10 @@ def test_print_columns(mock, capsys):
 def test_print_columns_2(mock, capsys):
     columns = columnize(['a', 'b', 'ccc', 'dddd'])
     assert '\n'.join(columns) == "a   \nb   \nccc \ndddd"
+
+
+@patch('pew._print_utils.get_terminal_size', return_value=(9, 1))
+def test_print_columns_3(mock, capsys):
+    columns = list(columnize(['aaa', 'b', 'c', 'd', 'e', 'fff']))
+    assert max(map(len, columns)) <= 9
+    assert '\n'.join(columns) == "aaa  d  \nb    e  \nc    fff"


### PR DESCRIPTION
Some combinations of short and long env names caused the list to be split across too many columns. This in turn caused some lines in the list to wrap onto multiple lines, breaking the nice table.