### PR TITLE
Add `getproject` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,14 @@ Bind an existing virtualenv to an existing project.
 
 When no arguments are given, the current virtualenv and current directory are assumed.
 
+### getproject ###
+
+Return a virtualenv's project directory.
+
+`usage: pew getproject [env]`
+
+When no arguments are given, the current virtualenv is assumed.
+
 ### restore ###
 
 Try to restore a broken virtualenv by reinstalling the same python

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -518,15 +518,30 @@ def getproject_cmd(argv):
     If called without providing a virtualenv name as argument, print the
     current virtualenv's project directory.
     """
-    env = argv[0] if argv else os.environ.get('VIRTUAL_ENV')
-    if not env:
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Print an environment's project directory.",
+    )
+    parser.add_argument(
+        'envname',
+        nargs='?',
+        default=os.environ.get('VIRTUAL_ENV'),
+        help=(
+            'The name of the environment to return the project directory '
+            'for.  If omitted, will use the currently active environment.'
+        ),
+    )
+    args = parser.parse_args(argv)
+    # Now, do the actual work
+    if not args.envname:
         sys.exit('ERROR: no virtualenv active')
-    if not (workon_home / env).exists():
-        sys.exit("ERROR: Environment '{0}' does not exist.".format(env))
-    project_dir = get_project_dir(env)
+    if not (workon_home / args.envname).exists():
+        sys.exit("ERROR: Environment '{0}' does not exist."
+                 .format(args.envname))
+    project_dir = get_project_dir(args.envname)
     if project_dir is None:
         sys.exit("ERROR: no project directory set for Environment '{0}'"
-                 .format(env))
+                 .format(args.envname))
     print(project_dir)
 
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -512,6 +512,24 @@ def setproject_cmd(argv):
     setvirtualenvproject(env, project)
 
 
+def getproject_cmd(argv):
+    """Print a virtualenv's project directory, if set.
+
+    If called without providing a virtualenv name as argument, print the
+    current virtualenv's project directory.
+    """
+    env = argv[0] if argv else os.environ.get('VIRTUAL_ENV')
+    if not env:
+        sys.exit('ERROR: no virtualenv active')
+    if not (workon_home / env).exists():
+        sys.exit("ERROR: Environment '{0}' does not exist.".format(env))
+    project_dir = get_project_dir(env)
+    if project_dir is None:
+        sys.exit("ERROR: no project directory set for Environment '{0}'"
+                 .format(env))
+    print(project_dir)
+
+
 def mkproject_cmd(argv):
     """Create a new project directory and its associated virtualenv."""
     if '-l' in argv or '--list' in argv:

--- a/tests/test_getproject.py
+++ b/tests/test_getproject.py
@@ -7,7 +7,7 @@ from utils import TemporaryDirectory
 
 
 def test_getproject(env1):
-    """Check that ``getproject`` prints an environment’s project directory."""
+    """Check that ``getproject`` prints an environment's project directory."""
     with temp_environ():
         os.environ.pop('VIRTUAL_ENV', None)
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_getproject.py
+++ b/tests/test_getproject.py
@@ -1,0 +1,60 @@
+"""Tests for the ``getproject`` subcommand."""
+
+import os
+
+from pew._utils import temp_environ, invoke_pew as invoke
+from utils import TemporaryDirectory
+
+
+def test_getproject(env1):
+    """Check that ``getproject`` prints an environment’s project directory."""
+    with temp_environ():
+        os.environ.pop('VIRTUAL_ENV', None)
+        with TemporaryDirectory() as tmpdir:
+            invoke('setproject', 'env1', tmpdir)
+            res = invoke('getproject', 'env1')
+            assert not res.err
+            assert res.out == tmpdir
+
+
+def test_project_directory_not_set(env1):
+    """Check the error message if no project directory was set.
+
+    If no project directory has been configured for an environment,
+    ``getproject`` should quit with an error message.
+    """
+    name = 'env1'
+    with temp_environ():
+        os.environ.pop('VIRTUAL_ENV', None)
+        with TemporaryDirectory() as tmpdir:
+            res = invoke('getproject', name)
+            assert not res.out
+            assert res.err == (
+                "ERROR: no project directory set for Environment '{0}'"
+                .format(name)
+            )
+
+
+def test_unknown_environment():
+    """Check the error message if passed an unknown environment name.
+
+    If ``getproject`` is invoked with the name of an environment that
+    does not exist, the call should fail with an appropriate error
+    message.
+    """
+    name = 'bogus-environment-that-/hopefully/-does-not-exist'
+    res = invoke('getproject', name)
+    assert not res.out
+    assert res.err == "ERROR: Environment '{0}' does not exist.".format(name)
+
+
+def test_call_without_args_outside_active_venv():
+    """Check the error message if called without args outside a virtualenv.
+
+    If ``getproject`` is called without additional arguments outside of
+    an active virtualenv, it should print an error message.
+    """
+    os.environ.pop('VIRTUAL_ENV', None)
+    res = invoke('getproject')
+    assert not res.out
+    assert res.err == "ERROR: no virtualenv active"


### PR DESCRIPTION
Use `pew getproject [env]` to print the given virtualenv's project directory, if one has been set.  If the `env` parameter is omitted, use the currently active virtualenv.