### PR TITLE
Quote properly in first_run_setup config line

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -746,7 +746,7 @@ def first_run_setup():
         if shell == 'fish':
             source_cmd = 'source (pew shell_config)'
         else:
-            source_cmd = 'source $(pew shell_config)'
+            source_cmd = 'source "$(pew shell_config)"'
         rcpath = expandpath({'bash': '~/.bashrc'
                            , 'zsh': '~/.zshrc'
                            , 'fish': '~/.config/fish/config.fish'}[shell])


### PR DESCRIPTION
This makes this line behave predictably with no assumptions on what
characters might be present in the path `pew` is installed in.