### PR TITLE
Compute basename eagerly for Bash prompt

### DIFF
--- a/pew/shell_config/init.bash
+++ b/pew/shell_config/init.bash
@@ -1,3 +1,3 @@
 source "$( dirname "${BASH_SOURCE[0]}" )"/complete.bash
 
-[[ -z "${VIRTUAL_ENV}" ]] || PS1="\[\033[01;34m\]\$(basename '$VIRTUAL_ENV')\[\e[0m\] $PS1"
+[[ -z "${VIRTUAL_ENV}" ]] || PS1="\[\033[01;34m\]$(basename "$VIRTUAL_ENV")\[\e[0m\] $PS1"


### PR DESCRIPTION
Before:

  $ echo "$PS1"
  \[\033[01;34m\]$(basename '/home/greg/.local/share/virtualenvs/jupyter')\[\e[0m\] ...old PS1...

After:

  $ echo "$PS1"
  \[\033[01;34m\]jupyter\[\e[0m\] ...old PS1...

This is simpler, and moreover avoids the need to fork and exec
a `/usr/bin/basename` process each time the prompt is printed.