### PR TITLE
Drop EOL'd Python 3.3 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,6 @@ matrix:
       script: py.test -rws tests/
     - language: python
       sudo: false
-      python: "3.3"
-      install:
-        - pip install -e . --upgrade
-        - pip install pytest
-      script: py.test -rws tests/ --ignore=tests/test_install.py
-    - language: python
-      sudo: false
       python: "3.4"
       install:
         - pip install -e . --upgrade


### PR DESCRIPTION
Python 3.3 reached EOL a couple of months ago, and setuptools dropped support
for it earlier this year: pypa/setuptools@7392f01ff . As a result, the 3.3 entry in the
build matrix has been erroring out since at least #196.