### PR TITLE
Fix list_pythons crash when Pythonz is not installed.

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -663,7 +663,7 @@ def list_pythons_cmd(argv):
     '''List the pythons installed by Pythonz (or all the installable ones)'''
     try:
         Path(PATH_PYTHONS).mkdir(parents=True)
-    except OSError:
+    except (OSError, NameError):
         pass
     ListPythons().run(argv)
 


### PR DESCRIPTION
Before:

```
$ pew list_pythons
Traceback (most recent call last):
  File "/usr/sbin/pew", line 11, in <module>
    load_entry_point('pew==1.1.5', 'console_scripts', 'pew')()
  File "/usr/lib/python3.7/site-packages/pew/pew.py", line 758, in pew
    return command(sys.argv[2:])
  File "/usr/lib/python3.7/site-packages/pew/pew.py", line 662, in list_pythons_cmd
    Path(PATH_PYTHONS).mkdir(parents=True)
NameError: name 'PATH_PYTHONS' is not defined
```

After:

```
$ pew list_pythons
You need to install the pythonz extra.  pip install pew[pythonz]
```