### PR TITLE
Use Shellingham for shell detection on Windows

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ name = "pypi"
 virtualenv = "==1.11.6"
 "virtualenv-clone" = "==0.2.5"
 "pythonz-bd" = {"version" = "*", "sys_platform" = "!='win32'" }
-"psutil" = {"version" = "*", "sys_platform" = "=='win32'" }
+"shellingham" = {"version" = "*", "sys_platform" = "=='win32'" }
 
 [dev-packages]
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -36,7 +36,7 @@ else:
     InstallCommand = ListPythons = LocatePython = UninstallCommand = \
         lambda : sys.exit('Command not supported on this platform')
 
-    import psutil
+    import shellingham
 
 from pew._utils import (check_call, invoke, expandpath, own, env_bin_dir,
                         check_path, temp_environ, NamedTemporaryFile, to_unicode)
@@ -184,7 +184,10 @@ def _detect_shell():
         if 'CMDER_ROOT' in os.environ:
             shell = 'Cmder'
         elif windows:
-            shell = psutil.Process(os.getpid()).parent().parent().name()
+            try:
+                _, shell = shellingham.detect_shell()
+            except shellingham.ShellDetectionFailure:
+                shell = os.environ['COMSPEC']
         else:
             shell = 'sh'
     return shell

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -187,7 +187,7 @@ def _detect_shell():
             try:
                 _, shell = shellingham.detect_shell()
             except shellingham.ShellDetectionFailure:
-                shell = os.environ['COMSPEC']
+                shell = os.environ.get('COMSPEC', 'cmd.exe')
         else:
             shell = 'sh'
     return shell
@@ -370,7 +370,7 @@ def workon_cmd(argv):
     project_dir = get_project_dir(env)
     if project_dir is None or argv[-1] == '--here': # TODO: use argparse
         project_dir = os.getcwd()
-    
+
     shell(env, cwd=project_dir)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ virtualenv
 virtualenv-clone==0.2.5
 pytest
 pythonz-bd==1.11.2 ; sys_platform != 'win32'
-psutil ; sys_platform == 'win32'
+shellingham ; sys_platform == 'win32'
 stdeb ; sys_platform == 'linux'

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
             'pathlib'
         ],
         ':sys_platform=="win32"': [
-            'psutil'
+            'shellingham'
         ],
         'pythonz': [
             'pythonz-bd>=1.10.2'

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -11,6 +11,7 @@ import pytest
 check_env = [sys.executable, '-c', "import os; print(os.environ['VIRTUAL_ENV'])"]
 check_cwd = [sys.executable, '-c', "import pathlib; print(pathlib.Path().absolute())"]
 
+@pytest.mark.shell
 def test_detect_shell():
     with temp_environ():
         try:
@@ -18,7 +19,12 @@ def test_detect_shell():
         except KeyError:
             pass
         if sys.platform == 'win32':
-            assert _detect_shell() in ['cmd.exe']
+            # NOTE: This assumes your current shell is CMD, and would fail if
+            # you run the test in e.g. Powershell. You can safely ignore the
+            # error as long as the _detect_shell() makes sense to you.
+            # Hint: Disable this test like this: pytest -m 'not shell'
+            # https://github.com/berdario/pew/pull/204#discussion_r273835108
+            assert _detect_shell() == 'cmd.exe'
         else:
             assert _detect_shell() == 'sh'
         os.environ['SHELL'] = 'foo'

--- a/tests/test_workon.py
+++ b/tests/test_workon.py
@@ -18,7 +18,7 @@ def test_detect_shell():
         except KeyError:
             pass
         if sys.platform == 'win32':
-            assert _detect_shell() in ['python.exe']
+            assert _detect_shell() in ['cmd.exe']
         else:
             assert _detect_shell() == 'sh'
         os.environ['SHELL'] = 'foo'


### PR DESCRIPTION
Close #182.

Detection logic based on [Shellingham’s documentation](https://github.com/sarugaku/shellingham#notes-for-application-developers).