### PR TITLE
Fix setproject_cmd documentation

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -517,7 +517,7 @@ def setvirtualenvproject(env, project):
 
 
 def setproject_cmd(argv):
-    """Given a virtualenv directory and a project directory, set the
+    """Given a virtualenv directory and a project directory, set the \
     virtualenv up to be associated with the project."""
     args = dict(enumerate(argv))
     project = os.path.abspath(args.get(1, '.'))


### PR DESCRIPTION
Hello,

Currently, when running `pew --help`, the setproject command documentation is truncated. This PR fixes this.

Before:
```
pew
Available commands:
[...]
 setproject:               Given a virtualenv directory and a project directory, set the
```

After:
```
pew
Available commands:
[...]
 setproject:               Given a virtualenv directory and a project directory, set the virtualenv up to be associated with the project.
```

Thank you for this usefull cli! 

Maxime