### PR TITLE
Doing proper import

### DIFF
--- a/pew/pew.py
+++ b/pew/pew.py
@@ -395,7 +395,7 @@ def sitepackages_dir(env=os.environ.get('VIRTUAL_ENV')):
         sys.exit('ERROR: no virtualenv active')
     else:
         env_python = workon_home / env / env_bin_dir / 'python'
-        return Path(invoke(str(env_python), '-c', 'import distutils; \
+        return Path(invoke(str(env_python), '-c', 'import distutils.sysconfig; \
 print(distutils.sysconfig.get_python_lib())').out)
 
 


### PR DESCRIPTION
It appears as if in certain later versions of Python, `import distutils; print(distutils.sysconfig.get_python_lib())` raises an AttributeError.

I ran into this while attempting to use `pew add`. Basically, because this errors out, it would return my sitepackages directory was an empty string, thus breaking `pew add`. This fixes it.

![image](https://user-images.githubusercontent.com/19521402/75389404-0df4fd00-58ac-11ea-8382-5b2d1b5c9421.png)
