### PR TITLE
Fix "python install" command for python >= 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             'shellingham'
         ],
         'pythonz': [
-            'pythonz'
+            'pythonz-bd @ git+https://github.com/M0dM/pythonz.git@bd'
         ]
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             'shellingham'
         ],
         'pythonz': [
-            'pythonz-bd @ git+https://github.com/M0dM/pythonz.git@bd'
+            'pythonz @ git+https://github.com/M0dM/pythonz.git'
         ]
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             'shellingham'
         ],
         'pythonz': [
-            'pythonz-bd>=1.10.2'
+            'pythonz-bd @ git+https://github.com/M0dM/pythonz.git@bd'
         ]
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
             'shellingham'
         ],
         'pythonz': [
-            'pythonz-bd @ git+https://github.com/M0dM/pythonz.git@bd'
+            'pythonz'
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
I have forked pythonz-bd as it does not work when python minor version have more than one digit. 