### PR TITLE
Add option `--pip-cmd` to pass `uv` as an alternative package installer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ When invoked without arguments `pew` will output the list of all commands with e
 
 Create a new environment, in the WORKON_HOME.
 
-`usage: pew new [-hd] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] envname`
+`usage: pew new [-hd] [-p PYTHON] [-c {pip,uv}] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] envname`
 
 The new environment is automatically activated after being initialized.
 
@@ -249,6 +249,8 @@ The `-a` option can be used to associate an existing project directory with the 
 The `-i` option can be used to install one or more packages (by repeating the option) after the environment is created.
 
 The `-r` option can be used to specify a text file listing packages to be installed. The argument value is passed to `pip -r` to be installed.
+
+The `-c` option can be used to pass an alternative package installer. Currently supporting [uv](https://github.com/astral-sh/uv).
 
 ### workon ###
 
@@ -262,7 +264,7 @@ If no `envname` is given the list of available environments is printed to stdout
 
 Create a temporary virtualenv.
 
-`usage: pew mktmpenv [-h] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS]`
+`usage: pew mktmpenv [-h] [-p PYTHON] [-c {pip,uv}] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS]`
 
 ### ls ###
 
@@ -362,7 +364,7 @@ Controls whether the active virtualenv will access the packages in the global Py
 
 Create a new virtualenv in the `WORKON_HOME` and project directory in `PROJECT_HOME`.
 
-`usage: pew mkproject [-hd] [-p PYTHON] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] [-t TEMPLATES] [-l] envname`
+`usage: pew mkproject [-hd] [-p PYTHON] [-c {pip,uv}] [-i PACKAGES] [-a PROJECT] [-r REQUIREMENTS] [-t TEMPLATES] [-l] envname`
 
 The template option may be repeated to have several templates used to create a new project. The templates are applied in the order named on the command line. All other options are passed to `pew new` to create a virtual environment with the same name as the project.
 

--- a/pew/__main__.py
+++ b/pew/__main__.py
@@ -1,3 +1,3 @@
-from pew.pew import pew
+from pew.pew import main
 
-pew()
+main()

--- a/pew/_utils.py
+++ b/pew/_utils.py
@@ -1,13 +1,11 @@
 import os
 import sys
 import locale
-from codecs import getwriter
 from contextlib import contextmanager
 from subprocess import check_call, Popen, PIPE
 from collections import namedtuple
-from functools import partial, wraps
+from functools import partial
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from shutil import which
 
 windows = sys.platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'deb': DebCommand
     },
     entry_points={
-        'console_scripts': ['pew = pew.pew:pew']},
+        'console_scripts': ['pew = pew.pew:main']},
     classifiers=[
         'Programming Language :: Python :: 3',
         'Intended Audience :: Developers',

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from pew.pew import pew
+
+
+@pytest.fixture
+def mocked_check_call():
+    with patch("pew.pew.check_call") as mock:
+        yield mock
+
+
+@pytest.mark.usefixtures("workon_home")
+@pytest.mark.parametrize(
+    "pip_cmd,exp_call", 
+    [
+        ("pip", ["pip", "install", "pew"]), 
+        ("uv", ["uv", "pip", "install", "pew"]),
+    ]
+)
+def test_pip_cmd_option(mocked_check_call, pip_cmd, exp_call):
+    pew(["new", "-d", "--pip-cmd", pip_cmd, "-i", "pew", str(uuid4())])
+    assert mocked_check_call.called
+    assert mocked_check_call.call_args[0][0] == exp_call

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters=True
-envlist = py{36,37,38,39,310}-{linux,windows}, pypy3
+envlist = py{36,37,38,39,310,311}-{linux,windows}, pypy3
 
 [gh-actions]
 python =
@@ -9,6 +9,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Add the command-line option `--pip-cmd` to allow using [uv](https://github.com/astral-sh/uv) as an alternative package installer.

Example usage:

```
pew new --pip-cmd=uv -p=python3.11 -r requirements.txt test-pip-uv
```